### PR TITLE
update mongo storage

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -14,7 +14,7 @@ func main() {
 
 	// Custom storage
 	store := mongodb.New(mongodb.Config{
-		Addr: 		"127.0.0.1:27017", 
+		URI: 		"mongodb://127.0.0.1:27017", 
 		Database: 	"_database", 
 		Collection: 	"_storage",
 	})

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -18,6 +18,10 @@ func main() {
 		Database: 	"_database", 
 		Collection: 	"_storage",
 	})
+   
+   // Access DB connection
+   // for disconnet for example
+   store.DB.Client().Disconnect(context.TODO())
 }
 
 ```

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -15,7 +15,9 @@ import (
 // Config defines the config for storage.
 type Config struct {
 	// Custom options
-	Addr       string
+
+	//https://docs.mongodb.com/manual/reference/connection-string/
+	URI        string
 	Database   string
 	Collection string
 
@@ -52,15 +54,15 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Addr:       "127.0.0.1:27017",
+	URI:        "mongodb://127.0.0.1:27017",
 	Database:   "_database",
 	Collection: "_storage",
 }
 
 // Helper function to set default values
 func configDefault(cfg Config) Config {
-	if cfg.Addr == "" {
-		cfg.Addr = ConfigDefault.Addr
+	if cfg.URI == "" {
+		cfg.URI = ConfigDefault.URI
 	}
 	if cfg.Database == "" {
 		cfg.Database = ConfigDefault.Database


### PR DESCRIPTION
- Use URI instead of Addr, because mongodb has different [connection string format](https://docs.mongodb.com/manual/reference/connection-string/)
eg:
```
mongodb://localhost:27017
mongodb+srv://server.example.com/
mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?replicaSet=mySet&authSource=authDB
mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?connectTimeoutMS=300000&replicaSet=mySet&authSource=aDifferentAuthDB
```

- Expose `DB` as public API to for operation like disconnect
- Fix panic on connection option
   - originally the `HeartbeatInterval` is `*time.Duration`, and the driver internally check for not nil
  - our version of `HeartbeatInterval` is `time.Duration`, not pointer, so it default to zero, need to explicitly check for that
- update test case