### PR TITLE
👷 Improve memory storage

### DIFF
--- a/memory/config.go
+++ b/memory/config.go
@@ -7,16 +7,15 @@ type Config struct {
 	GCInterval time.Duration
 }
 
-// ConfigDefault is the default config
-var ConfigDefault = Config{
+var defaultConfig = Config{
 	GCInterval: 10 * time.Second,
 }
 
-// Helper function to set default values
+// configDefault is a helper function to set default values
 func configDefault(config ...Config) Config {
 	// Return default config if nothing provided
 	if len(config) < 1 {
-		return ConfigDefault
+		return defaultConfig
 	}
 
 	// Override default config
@@ -24,7 +23,7 @@ func configDefault(config ...Config) Config {
 
 	// Set default values
 	if int(cfg.GCInterval) == 0 {
-		cfg.GCInterval = ConfigDefault.GCInterval
+		cfg.GCInterval = defaultConfig.GCInterval
 	}
 	return cfg
 }

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -43,7 +43,7 @@ func (s *Storage) Get(key string) ([]byte, error) {
 		return nil, nil
 	}
 
-	if v.expiry <= time.Now().Unix() && v.expiry != 0 {
+	if v.expiry != 0 && v.expiry <= time.Now().Unix() {
 		return nil, nil
 	}
 
@@ -80,15 +80,11 @@ func (s *Storage) Clear() error {
 }
 
 func (s *Storage) gc() {
-	tick := time.NewTicker(s.gcInterval)
-	for {
-		<-tick.C
-
+	for t := range time.NewTicker(s.gcInterval).C {
+		now := t.Unix()
 		s.mux.Lock()
-
-		now := time.Now().Unix()
 		for id, v := range s.db {
-			if v.expiry < now && v.expiry != 0 {
+			if v.expiry != 0 && v.expiry < now {
 				delete(s.db, id)
 			}
 		}


### PR DESCRIPTION
- Solve data race in test and make test coverage 100%
- Change `ConfigDefault` to `defaultConfig` and make it private(There is no reason to make it public, right?)
- Make all test cases parallel
- `v.expiry != 0` is cheaper than `v.expiry <= time.Now().Unix()`
- `<-Ticker.C` is already current time(`time.Now()`)