### PR TITLE
Add support for MongoDB Atlas

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -41,6 +41,7 @@ store := mongodb.New()
 
 // Initialize custom config
 store := mongodb.New(mongodb.Config{
+	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",
@@ -52,6 +53,11 @@ store := mongodb.New(mongodb.Config{
 ### Config
 ```go
 type Config struct {
+	// Whether the DB is hosted on MongoDB Atlas
+	//
+	// Optional. Default is false
+	Atlas bool
+
 	// Host name where the DB is hosted
 	//
 	// Optional. Default is "127.0.0.1"
@@ -92,6 +98,7 @@ type Config struct {
 ### Default Config
 ```go
 var ConfigDefault = Config{
+	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -2,6 +2,11 @@ package mongodb
 
 // Config defines the config for storage.
 type Config struct {
+	// Whether the DB is hosted on MongoDB Atlas
+	//
+	// Optional. Default is false
+	Atlas bool
+
 	// Host name where the DB is hosted
 	//
 	// Optional. Default is "127.0.0.1"
@@ -40,6 +45,7 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
+	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -48,7 +48,11 @@ func New(config ...Config) *Storage {
 	if cfg.Username != "" || cfg.Password != "" {
 		dsn += "@"
 	}
-	dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
+	if cfg.Atlas == true {
+		dsn += url.QueryEscape(cfg.Host) // Cannot specify port when using MongoDB Atlas
+	} else {
+		dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
+	}
 
 	// Set mongo options
 	opt := options.Client()

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -34,7 +34,7 @@ func New(config ...Config) *Storage {
 
 	// Create data source name
 	var dsn = "mongodb"
-	if cfg.Atlas == true {
+	if cfg.Atlas {
 		dsn += "+srv://"
 	} else {
 		dsn += "://"
@@ -48,8 +48,9 @@ func New(config ...Config) *Storage {
 	if cfg.Username != "" || cfg.Password != "" {
 		dsn += "@"
 	}
-	if cfg.Atlas == true {
-		dsn += url.QueryEscape(cfg.Host) // Cannot specify port when using MongoDB Atlas
+	// Cannot specify port when using MongoDB Atlas
+	if cfg.Atlas {
+		dsn += url.QueryEscape(cfg.Host)
 	} else {
 		dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
 	}

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -33,7 +33,12 @@ func New(config ...Config) *Storage {
 	cfg := configDefault(config...)
 
 	// Create data source name
-	var dsn = "mongodb://"
+	var dsn = "mongodb"
+	if cfg.Atlas == true {
+		dsn += "+srv://"
+	} else {
+		dsn += "://"
+	}
 	if cfg.Username != "" {
 		dsn += url.QueryEscape(cfg.Username)
 	}


### PR DESCRIPTION
This PR adds support for using MongoDB Atlas connections inside Storage.

There is a new boolean option in the config named `Atlas`, and if that is enabled it does the following:
1. Change the protocol to use `mongodb+srv://` (instead of `mongodb://`)
2. Remove the port from the connection string

I didn't see any contribution guidelines, so please let me know if I should change anything here.