### PR TITLE
Add support for MongoDB connection string

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -48,11 +48,25 @@ store := mongodb.New(mongodb.Config{
 	Collection: "fiber_storage",
 	Reset:      false,
 })
+
+// Initialize custom config using connection string
+store := mongodb.New(mongodb.Config{
+	Connection: "mongodb://user:password@127.0.0.1:27017",
+	Database:   "fiber",
+	Collection: "fiber_storage",
+	Reset:      false,
+})
+
 ```
 
 ### Config
 ```go
 type Config struct {
+	// Connection string to use for DB. Will override all other authentication values if used
+	//
+	// Optional. Default is ""
+	Connection string
+
 	// Whether the DB is hosted on MongoDB Atlas
 	//
 	// Optional. Default is false
@@ -98,6 +112,7 @@ type Config struct {
 ### Default Config
 ```go
 var ConfigDefault = Config{
+	Connection: "",
 	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -41,7 +41,6 @@ store := mongodb.New()
 
 // Initialize custom config
 store := mongodb.New(mongodb.Config{
-	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",
@@ -66,11 +65,6 @@ type Config struct {
 	//
 	// Optional. Default is ""
 	Connection string
-
-	// Whether the DB is hosted on MongoDB Atlas
-	//
-	// Optional. Default is false
-	Atlas bool
 
 	// Host name where the DB is hosted
 	//
@@ -113,7 +107,6 @@ type Config struct {
 ```go
 var ConfigDefault = Config{
 	Connection: "",
-	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -50,10 +50,10 @@ store := mongodb.New(mongodb.Config{
 
 // Initialize custom config using connection string
 store := mongodb.New(mongodb.Config{
-	Connection: "mongodb://user:password@127.0.0.1:27017",
-	Database:   "fiber",
-	Collection: "fiber_storage",
-	Reset:      false,
+	ConnectionURI: "mongodb://user:password@127.0.0.1:27017",
+	Database:   	 "fiber",
+	Collection: 	 "fiber_storage",
+	Reset:      	 false,
 })
 
 ```
@@ -64,7 +64,7 @@ type Config struct {
 	// Connection string to use for DB. Will override all other authentication values if used
 	//
 	// Optional. Default is ""
-	Connection string
+	ConnectionURI string
 
 	// Host name where the DB is hosted
 	//
@@ -106,11 +106,11 @@ type Config struct {
 ### Default Config
 ```go
 var ConfigDefault = Config{
-	Connection: "",
-	Host:       "127.0.0.1",
-	Port:       27017,
-	Database:   "fiber",
-	Collection: "fiber_storage",
-	Reset:      false,
+	ConnectionURI: "",
+	Host:          "127.0.0.1",
+	Port:          27017,
+	Database:      "fiber",
+	Collection:    "fiber_storage",
+	Reset:         false,
 }
 ```

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -2,6 +2,11 @@ package mongodb
 
 // Config defines the config for storage.
 type Config struct {
+	// Connection string to use for DB. Will override all other authentication values if used
+	//
+	// Optional. Default is ""
+	Connection string
+
 	// Whether the DB is hosted on MongoDB Atlas
 	//
 	// Optional. Default is false
@@ -45,6 +50,7 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
+	Connection: "",
 	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -5,7 +5,7 @@ type Config struct {
 	// Connection string to use for DB. Will override all other authentication values if used
 	//
 	// Optional. Default is ""
-	Connection string
+	ConnectionURI string
 
 	// Host name where the DB is hosted
 	//
@@ -45,12 +45,12 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Connection: "",
-	Host:       "127.0.0.1",
-	Port:       27017,
-	Database:   "fiber",
-	Collection: "fiber_storage",
-	Reset:      false,
+	ConnectionURI: "",
+	Host:          "127.0.0.1",
+	Port:          27017,
+	Database:      "fiber",
+	Collection:    "fiber_storage",
+	Reset:         false,
 }
 
 // Helper function to set default values

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -7,11 +7,6 @@ type Config struct {
 	// Optional. Default is ""
 	Connection string
 
-	// Whether the DB is hosted on MongoDB Atlas
-	//
-	// Optional. Default is false
-	Atlas bool
-
 	// Host name where the DB is hosted
 	//
 	// Optional. Default is "127.0.0.1"
@@ -51,7 +46,6 @@ type Config struct {
 // ConfigDefault is the default config
 var ConfigDefault = Config{
 	Connection: "",
-	Atlas:      false,
 	Host:       "127.0.0.1",
 	Port:       27017,
 	Database:   "fiber",

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -39,12 +39,7 @@ func New(config ...Config) *Storage {
 	if cfg.Connection != "" {
 		dsn = cfg.Connection
 	} else {
-		dsn = "mongodb"
-		if cfg.Atlas {
-			dsn += "+srv://"
-		} else {
-			dsn += "://"
-		}
+		dsn = "mongodb://"
 		if cfg.Username != "" {
 			dsn += url.QueryEscape(cfg.Username)
 		}
@@ -54,12 +49,7 @@ func New(config ...Config) *Storage {
 		if cfg.Username != "" || cfg.Password != "" {
 			dsn += "@"
 		}
-		// Cannot specify port when using MongoDB Atlas
-		if cfg.Atlas {
-			dsn += url.QueryEscape(cfg.Host)
-		} else {
-			dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
-		}
+		dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
 	}
 
 	// Set mongo options

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -33,26 +33,33 @@ func New(config ...Config) *Storage {
 	cfg := configDefault(config...)
 
 	// Create data source name
-	var dsn = "mongodb"
-	if cfg.Atlas {
-		dsn += "+srv://"
+	var dsn string
+
+	// Check if user supplied connection string
+	if cfg.Connection != "" {
+		dsn = cfg.Connection
 	} else {
-		dsn += "://"
-	}
-	if cfg.Username != "" {
-		dsn += url.QueryEscape(cfg.Username)
-	}
-	if cfg.Password != "" {
-		dsn += ":" + cfg.Password
-	}
-	if cfg.Username != "" || cfg.Password != "" {
-		dsn += "@"
-	}
-	// Cannot specify port when using MongoDB Atlas
-	if cfg.Atlas {
-		dsn += url.QueryEscape(cfg.Host)
-	} else {
-		dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
+		dsn = "mongodb"
+		if cfg.Atlas {
+			dsn += "+srv://"
+		} else {
+			dsn += "://"
+		}
+		if cfg.Username != "" {
+			dsn += url.QueryEscape(cfg.Username)
+		}
+		if cfg.Password != "" {
+			dsn += ":" + cfg.Password
+		}
+		if cfg.Username != "" || cfg.Password != "" {
+			dsn += "@"
+		}
+		// Cannot specify port when using MongoDB Atlas
+		if cfg.Atlas {
+			dsn += url.QueryEscape(cfg.Host)
+		} else {
+			dsn += fmt.Sprintf("%s:%d", url.QueryEscape(cfg.Host), cfg.Port)
+		}
 	}
 
 	// Set mongo options

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -36,8 +36,8 @@ func New(config ...Config) *Storage {
 	var dsn string
 
 	// Check if user supplied connection string
-	if cfg.Connection != "" {
-		dsn = cfg.Connection
+	if cfg.ConnectionURI != "" {
+		dsn = cfg.ConnectionURI
 	} else {
 		dsn = "mongodb://"
 		if cfg.Username != "" {


### PR DESCRIPTION
Adds support for supplying a MongoDB connection URI with `Connection` instead of using the `Host`, `Port`, `User`, and `Password` config options.

Two questions:
1. Is `Connection` the right config name for this?
2. Should the `Atlas` option be removed since Atlas users can now use connection strings instead?