### PR TITLE
:bug: Fix error with no badger options being loaded

### DIFF
--- a/badger/.gitignore
+++ b/badger/.gitignore
@@ -1,0 +1,3 @@
+fiber.badger/
+fiber.config.badger/
+fiber.with_options.badger/

--- a/badger/config.go
+++ b/badger/config.go
@@ -68,7 +68,10 @@ func configDefault(config ...Config) Config {
 		cfg.GCInterval = ConfigDefault.GCInterval
 	}
 	overrideLogger := false
-	if cfg.BadgerOptions.Dir == defaultDatabase && cfg.BadgerOptions.Dir != cfg.Database {
+	// Detecting if no default Badger option was given
+	// Also detects when a default badger option is given with a custom database name
+	if cfg.BadgerOptions.ValueLogFileSize <= 0 || cfg.BadgerOptions.Dir == "" || cfg.BadgerOptions.ValueDir == "" ||
+		(cfg.BadgerOptions.Dir == defaultDatabase && cfg.BadgerOptions.Dir != cfg.Database) {
 		cfg.BadgerOptions = badger.DefaultOptions(cfg.Database)
 		overrideLogger = true
 	}

--- a/badger/config_test.go
+++ b/badger/config_test.go
@@ -1,0 +1,36 @@
+package badger
+
+import (
+	"github.com/dgraph-io/badger/v3"
+	"github.com/gofiber/utils"
+	"testing"
+)
+
+func assertRecoveryPanic(t *testing.T) {
+	err := recover()
+	utils.AssertEqual(t, nil, err)
+}
+
+func Test_Badger_Only_Name(t *testing.T) {
+	defer assertRecoveryPanic(t)
+	testDB := New(Config{
+		Database:  "fiber.config.badger",
+		UseLogger: false,
+	})
+	utils.AssertEqual(t, nil, testDB.Close())
+}
+
+func Test_Badger_Options(t *testing.T) {
+	defer assertRecoveryPanic(t)
+	testDB := New(Config{
+		BadgerOptions: badger.DefaultOptions("fiber.with_options.badger"),
+		UseLogger:     false,
+	})
+	utils.AssertEqual(t, nil, testDB.Close())
+}
+
+func Test_Empty_Config(t *testing.T) {
+	defer assertRecoveryPanic(t)
+	testDB := New(Config{})
+	utils.AssertEqual(t, nil, testDB.Close())
+}


### PR DESCRIPTION
My apologies, I forget to test with only Database option given in Config, without using `ConfigDefault`

This PR, is a fix to this bug

When `BadgerOptions` is not passed, a panic error is thrown
```shell
panic: Invalid ValueLogFileSize, must be in range [1MB, 2GB)
```