### PR TITLE
[Feat] allow for usage of redis FailoverClient with Sentinel

### DIFF
--- a/redis/config.go
+++ b/redis/config.go
@@ -28,10 +28,31 @@ type Config struct {
 	Database int
 
 	// URL the standard format redis url to parse all other options. If this is set all other config options, Host, Port, Username, Password, Database have no effect.
+	// Danger: To avoid breaking existing code, URL cannot be used if a failover client with sentinel is desired
 	//
 	// Example: redis://<user>:<pass>@localhost:6379/<db>
 	// Optional. Default is ""
 	URL string
+
+	// EnableFailover to use redis FailoverClient with Sentinel instead of the standard redis Client
+	//
+	// Optional. Default is false
+	EnableFailover bool
+
+	// SentinelHosts where the Redis Sentinel is hosted
+	//
+	// Optional. Default is []string{}
+	SentinelHosts []string
+
+	// MasterName is the sentinel master's name
+	//
+	// Optional. Default is ""
+	MasterName string
+
+	// SentinelPassword
+	//
+	// Optional. Default is ""
+	SentinelPassword string
 
 	// Reset clears any existing keys in existing Collection
 	//
@@ -53,6 +74,10 @@ var ConfigDefault = Config{
 	Password: "",
 	URL:      "",
 	Database: 0,
+	EnableFailover: false,
+	SentinelHosts: []string{},
+	MasterName: "",
+	SentinelPassword: "",
 	Reset:    false,
 }
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,99 +1,107 @@
 package redis
 
 import (
-	"context"
-	"fmt"
-	"time"
+    "context"
+    "fmt"
+    "time"
 
-	"github.com/go-redis/redis/v8"
+    "github.com/go-redis/redis/v8"
 )
 
 // Storage interface that is implemented by storage providers
 type Storage struct {
-	db *redis.Client
+    db *redis.Client
 }
 
 // New creates a new redis storage
 func New(config ...Config) *Storage {
-	// Set default config
-	cfg := configDefault(config...)
+    // Set default config
+    cfg := configDefault(config...)
 
-	// Create new redis client
+    // Create new redis client
+    var db *redis.Client
 
-	var options *redis.Options
-	var err error
+    // URL takes precedent
+    if cfg.URL != "" {
+        options, err := redis.ParseURL(cfg.URL)
+        if err != nil {
+            panic(err)
+        }
+        db = redis.NewClient(options)
+    } else if cfg.EnableFailover {
+        options := &redis.FailoverOptions{
+            SentinelAddrs:    cfg.SentinelHosts,
+            MasterName:       cfg.MasterName,
+            SentinelPassword: cfg.SentinelPassword,
+            DB:               cfg.Database,
+            Password:         cfg.Password,
+        }
+        db = redis.NewFailoverClient(options)
+    } else {
+        options := &redis.Options{
+            Addr:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+            DB:       cfg.Database,
+            Username: cfg.Username,
+            Password: cfg.Password,
+        }
+        db = redis.NewClient(options)
+    }
 
-	if cfg.URL != "" {
-		options, err = redis.ParseURL(cfg.URL)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		options = &redis.Options{
-			Addr:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
-			DB:       cfg.Database,
-			Username: cfg.Username,
-			Password: cfg.Password,
-		}
-	}
+    // Test connection
+    if err := db.Ping(context.Background()).Err(); err != nil {
+        panic(err)
+    }
 
-	db := redis.NewClient(options)
+    // Empty collection if Clear is true
+    if cfg.Reset {
+        if err := db.FlushDB(context.Background()).Err(); err != nil {
+            panic(err)
+        }
+    }
 
-	// Test connection
-	if err := db.Ping(context.Background()).Err(); err != nil {
-		panic(err)
-	}
-
-	// Empty collection if Clear is true
-	if cfg.Reset {
-		if err := db.FlushDB(context.Background()).Err(); err != nil {
-			panic(err)
-		}
-	}
-
-	// Create new store
-	return &Storage{
-		db: db,
-	}
+    // Create new store
+    return &Storage{
+        db: db,
+    }
 }
 
 // Get value by key
 func (s *Storage) Get(key string) ([]byte, error) {
-	if len(key) <= 0 {
-		return nil, nil
-	}
-	val, err := s.db.Get(context.Background(), key).Bytes()
-	if err == redis.Nil {
-		return nil, nil
-	}
-	return val, err
+    if len(key) <= 0 {
+        return nil, nil
+    }
+    val, err := s.db.Get(context.Background(), key).Bytes()
+    if err == redis.Nil {
+        return nil, nil
+    }
+    return val, err
 }
 
 // Set key with value
 // Set key with value
 func (s *Storage) Set(key string, val []byte, exp time.Duration) error {
-	// Ain't Nobody Got Time For That
-	if len(key) <= 0 || len(val) <= 0 {
-		return nil
-	}
-	return s.db.Set(context.Background(), key, val, exp).Err()
+    // Ain't Nobody Got Time For That
+    if len(key) <= 0 || len(val) <= 0 {
+        return nil
+    }
+    return s.db.Set(context.Background(), key, val, exp).Err()
 }
 
 // Delete key by key
 func (s *Storage) Delete(key string) error {
-	// Ain't Nobody Got Time For That
-	if len(key) <= 0 {
-		return nil
-	}
-	return s.db.Del(context.Background(), key).Err()
+    // Ain't Nobody Got Time For That
+    if len(key) <= 0 {
+        return nil
+    }
+    return s.db.Del(context.Background(), key).Err()
 }
 
 // Reset all keys
 func (s *Storage) Reset() error {
-	return s.db.FlushDB(context.Background()).Err()
+    return s.db.FlushDB(context.Background()).Err()
 }
 
 // Close the database
 func (s *Storage) Close() error {
-	return s.db.Close()
+    return s.db.Close()
 }


### PR DESCRIPTION
We often use Redis Sentinel on Production environment for a more robust and highly available set up. This PR allows for configuration of Redis Sentinel on redis Storage Adapter and will not break any existing code.

Please consider merging this PR as some people might find this useful as well. 

Thank you! 


Changes:

allow config + init of redis FailoverClient with Sentinel to provide a more robust installation of Redis on Production environment.

- config.go: add relevant configuration options for Sentinel. These options will have not break existing code that depends on this library, if not configured explicitly.
- redis.go: add a step to init redis db with redis.NewFailoverClient() if EnableFailover=true (default false). To avoid breaking existing code, URL still takes precedent and only used to config Redis Standalone (i.e. cannot config Sentinel with URL as that would change the string format)

PS: Please let me know if anything needs revising. 