### PR TITLE
Public sqlite db options: MaxOpenConns, MaxIdleConns, ConnMaxLifetime.

### DIFF
--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -79,15 +79,18 @@ type Config struct {
 	// //////////////////////////////////
 
 	// MaxIdleConns sets the maximum number of connections in the idle connection pool.
-	// Default is 100.
+	//
+	// Optional. Default is 100.
 	MaxIdleConns int
 
 	// MaxOpenConns sets the maximum number of open connections to the database.
-	// Default is 100.
+	//
+	// Optional. Default is 100.
 	MaxOpenConns int
 
 	// ConnMaxLifetime sets the maximum amount of time a connection may be reused.
-	// Default is 1 second.
+	//
+	// Optional. Default is 1 second.
 	ConnMaxLifetime time.Duration
 }
 ```

--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -78,8 +78,16 @@ type Config struct {
 	// Adaptor related config options //
 	// //////////////////////////////////
 
-	MaxIdleConns    int
-	MaxOpenConns    int
+	// MaxIdleConns sets the maximum number of connections in the idle connection pool.
+	// Default is 100.
+	MaxIdleConns int
+
+	// MaxOpenConns sets the maximum number of open connections to the database.
+	// Default is 100.
+	MaxOpenConns int
+
+	// ConnMaxLifetime sets the maximum amount of time a connection may be reused.
+	// Default is 1 second.
 	ConnMaxLifetime time.Duration
 }
 ```

--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -41,10 +41,13 @@ store := sqlite3.New()
 
 // Initialize custom config
 store := sqlite3.New(sqlite3.Config{
-	Database:   "./fiber.sqlite3",
-	Table:      "fiber_storage",
-	Reset:      false,
-	GCInterval: 10 * time.Second,
+	Database:        "./fiber.sqlite3",
+	Table:           "fiber_storage",
+	Reset:           false,
+	GCInterval:      10 * time.Second,
+	MaxOpenConns:    100,
+	MaxIdleConns:    100,
+	ConnMaxLifetime: 1 * time.Second,
 })
 ```
 
@@ -70,15 +73,26 @@ type Config struct {
 	//
 	// Optional. Default is 10 * time.Second
 	GCInterval time.Duration
+
+	// //////////////////////////////////
+	// Adaptor related config options //
+	// //////////////////////////////////
+
+	MaxIdleConns    int
+	MaxOpenConns    int
+	ConnMaxLifetime time.Duration
 }
 ```
 
 ### Default Config
 ```go
 var ConfigDefault = Config{
-	Database:   "./fiber.sqlite3",
-	Table:      "fiber_storage",
-	Reset:      false,
-	GCInterval: 10 * time.Second,
+	Database:        "./fiber.sqlite3",
+	Table:           "fiber_storage",
+	Reset:           false,
+	GCInterval:      10 * time.Second,
+	MaxOpenConns:    100,
+	MaxIdleConns:    100,
+	ConnMaxLifetime: 1 * time.Second,
 }
 ```

--- a/sqlite3/config.go
+++ b/sqlite3/config.go
@@ -78,5 +78,14 @@ func configDefault(config ...Config) Config {
 	if int(cfg.GCInterval.Seconds()) <= 0 {
 		cfg.GCInterval = ConfigDefault.GCInterval
 	}
+	if cfg.MaxIdleConns <= 0 {
+		cfg.MaxIdleConns = ConfigDefault.MaxIdleConns
+	}
+	if cfg.MaxOpenConns <= 0 {
+		cfg.MaxOpenConns = ConfigDefault.MaxOpenConns
+	}
+	if cfg.ConnMaxLifetime == 0 {
+		cfg.ConnMaxLifetime = ConfigDefault.ConnMaxLifetime
+	}
 	return cfg
 }

--- a/sqlite3/config.go
+++ b/sqlite3/config.go
@@ -28,8 +28,16 @@ type Config struct {
 	// Adaptor related config options //
 	// //////////////////////////////////
 
-	MaxIdleConns    int
-	MaxOpenConns    int
+	// MaxIdleConns sets the maximum number of connections in the idle connection pool.
+	// Default is 100.
+	MaxIdleConns int
+
+	// MaxOpenConns sets the maximum number of open connections to the database.
+	// Default is 100.
+	MaxOpenConns int
+
+	// ConnMaxLifetime sets the maximum amount of time a connection may be reused.
+	// Default is 1 second.
 	ConnMaxLifetime time.Duration
 }
 

--- a/sqlite3/config.go
+++ b/sqlite3/config.go
@@ -29,15 +29,18 @@ type Config struct {
 	// //////////////////////////////////
 
 	// MaxIdleConns sets the maximum number of connections in the idle connection pool.
-	// Default is 100.
+	//
+	// Optional. Default is 100.
 	MaxIdleConns int
 
 	// MaxOpenConns sets the maximum number of open connections to the database.
-	// Default is 100.
+	//
+	// Optional. Default is 100.
 	MaxOpenConns int
 
 	// ConnMaxLifetime sets the maximum amount of time a connection may be reused.
-	// Default is 1 second.
+	//
+	// Optional. Default is 1 second.
 	ConnMaxLifetime time.Duration
 }
 

--- a/sqlite3/config.go
+++ b/sqlite3/config.go
@@ -24,13 +24,13 @@ type Config struct {
 	// Optional. Default is 10 * time.Second
 	GCInterval time.Duration
 
-	////////////////////////////////////
+	// //////////////////////////////////
 	// Adaptor related config options //
-	////////////////////////////////////
+	// //////////////////////////////////
 
-	maxIdleConns    int
-	maxOpenConns    int
-	connMaxLifetime time.Duration
+	MaxIdleConns    int
+	MaxOpenConns    int
+	ConnMaxLifetime time.Duration
 }
 
 // ConfigDefault is the default config
@@ -42,9 +42,9 @@ var ConfigDefault = Config{
 	GCInterval: 10 * time.Second,
 
 	// Adaptor related config options
-	maxOpenConns:    100,
-	maxIdleConns:    100,
-	connMaxLifetime: 1 * time.Second,
+	MaxOpenConns:    100,
+	MaxIdleConns:    100,
+	ConnMaxLifetime: 1 * time.Second,
 }
 
 // Helper function to set default values

--- a/sqlite3/sqlite3.go
+++ b/sqlite3/sqlite3.go
@@ -47,9 +47,9 @@ func New(config ...Config) *Storage {
 	}
 
 	// Set database options
-	db.SetMaxOpenConns(cfg.maxOpenConns)
-	db.SetMaxIdleConns(cfg.maxIdleConns)
-	db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	db.SetMaxOpenConns(cfg.MaxOpenConns)
+	db.SetMaxIdleConns(cfg.MaxIdleConns)
+	db.SetConnMaxLifetime(cfg.ConnMaxLifetime)
 
 	// Ping database
 	if err := db.Ping(); err != nil {


### PR DESCRIPTION
Default settings of `maxOpenConns` (100) and `connMaxLifetime` is not always good, so please allow to customize them. :)

We set max open connection to `1` to avoid the `SQLITE_BUSY` error.