### PR TITLE
Replace github.com/mattn/go-sqlite3 v2.0.3 by v1.14.10.

### DIFF
--- a/sqlite3/go.mod
+++ b/sqlite3/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/gofiber/utils v0.1.2
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/mattn/go-sqlite3 v1.14.10
 )

--- a/sqlite3/go.sum
+++ b/sqlite3/go.sum
@@ -1,4 +1,4 @@
 github.com/gofiber/utils v0.1.2 h1:1SH2YEz4RlNS0tJlMJ0bGwO0JkqPqvq6TbHK9tXZKtk=
 github.com/gofiber/utils v0.1.2/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.10 h1:MLn+5bFRlWMGoSRmJour3CL1w/qL96mvipqpwQW/Sfk=
+github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=


### PR DESCRIPTION
Quote from upstream (https://github.com/mattn/go-sqlite3):

> Latest stable version is v1.14 or later, not v2.
>
> NOTE: The increase to v2 was an accident. There were no major changes or features.