### PR TITLE
Copypasta in docs/comments with the right default port in redis adapter

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -68,7 +68,7 @@ type Config struct {
 
 	// Port where the DB is listening on
 	//
-	// Optional. Default is 3306
+	// Optional. Default is 6379
 	Port int
 
 	// Server username

--- a/redis/config.go
+++ b/redis/config.go
@@ -11,7 +11,7 @@ type Config struct {
 
 	// Port where the DB is listening on
 	//
-	// Optional. Default is 3306
+	// Optional. Default is 6379
 	Port int
 
 	// Server username


### PR DESCRIPTION
Nothing special. Just fixed this copypasta.