### PR TITLE
Added a default value for timeout while opening a boltDB.

### DIFF
--- a/bbolt/README.md
+++ b/bbolt/README.md
@@ -64,7 +64,7 @@ type Config struct {
 	// Timeout is the amount of time to wait to obtain a file lock.
 	// Only available on Darwin and Linux.
 	//
-	// Optional. Default is 0 (no timeout)
+	// Optional. Default is 60 * time.Second.
 	Timeout time.Duration
 
 	// Open database in read-only mode.
@@ -85,7 +85,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Database: "fiber.db",
 	Bucket:   "fiber_storage",
-	Timeout:  0,
+	Timeout:  60 * time.Second,
 	ReadOnly: false,
 	Reset:    false,
 }

--- a/bbolt/config.go
+++ b/bbolt/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	// Timeout is the amount of time to wait to obtain a file lock.
 	// Only available on Darwin and Linux.
 	//
-	// Optional. Default is 0 (no timeout)
+	// Optional. Default is set to 60 * time.Second.
 	Timeout time.Duration
 
 	// Open database in read-only mode.
@@ -35,7 +35,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Database: "fiber.db",
 	Bucket:   "fiber_storage",
-	Timeout:  0,
+	Timeout:  60 * time.Second,
 	ReadOnly: false,
 	Reset:    false,
 }


### PR DESCRIPTION
BoltDB obtains a file lock on the data file so multiple processes cannot open the same database at the same time. 
When one process is unable to acquire the lock over database file then it ends up **waiting indefinitely** for other process to release the lock over database file. 
To prevent an indefinite wait you can pass a timeout (other than 0) in options to the Open() function.
The main objective of this PR is if somebody uses the default value then it shouldn’t wait indefinitely while opening a boltDB.

Note:
I have set the default value of `Timeout` to `60 * time.Second` but I'm open for change. 