### PR TITLE
Support for configuring Redis connection pool size

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -50,6 +50,7 @@ store := redis.New(redis.Config{
 	Database:  0,
 	Reset:     false,
 	TLSConfig: nil,
+	PoolSize:  10 * runtime.GOMAXPROCS(0),
 }
 
 // or just the url with all information
@@ -102,6 +103,11 @@ type Config struct {
 	//
 	// Optional. Default is nil
 	TLSConfig *tls.Config
+
+	// Maximum number of socket connections.
+	//
+	// Optional. Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
+	PoolSize int
 }
 
 ```
@@ -117,5 +123,6 @@ var ConfigDefault = Config{
 	Database:  0,
 	Reset:     false,
 	TLSConfig: nil,
+	PoolSize:  10 * runtime.GOMAXPROCS(0),
 }
 ```

--- a/redis/config.go
+++ b/redis/config.go
@@ -1,6 +1,9 @@
 package redis
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"runtime"
+)
 
 // Config defines the config for storage.
 type Config struct {
@@ -43,6 +46,11 @@ type Config struct {
 	// TLS Config to use. When set TLS will be negotiated.
 	TLSConfig *tls.Config
 
+	// Maximum number of socket connections.
+	//
+	// Optional. Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
+	PoolSize int
+
 	////////////////////////////////////
 	// Adaptor related config options //
 	////////////////////////////////////
@@ -60,6 +68,7 @@ var ConfigDefault = Config{
 	Database:  0,
 	Reset:     false,
 	TLSConfig: nil,
+	PoolSize:  10 * runtime.GOMAXPROCS(0),
 }
 
 // Helper function to set default values

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -19,16 +19,18 @@ func New(config ...Config) *Storage {
 	cfg := configDefault(config...)
 
 	// Create new redis client
-
 	var options *redis.Options
 	var err error
 
 	if cfg.URL != "" {
 		options, err = redis.ParseURL(cfg.URL)
-		options.TLSConfig = cfg.TLSConfig
+
 		if err != nil {
 			panic(err)
 		}
+
+		options.TLSConfig = cfg.TLSConfig
+		options.PoolSize = cfg.PoolSize
 	} else {
 		options = &redis.Options{
 			Addr:      fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
@@ -36,6 +38,7 @@ func New(config ...Config) *Storage {
 			Username:  cfg.Username,
 			Password:  cfg.Password,
 			TLSConfig: cfg.TLSConfig,
+			PoolSize:  cfg.PoolSize,
 		}
 	}
 
@@ -71,7 +74,6 @@ func (s *Storage) Get(key string) ([]byte, error) {
 	return val, err
 }
 
-// Set key with value
 // Set key with value
 func (s *Storage) Set(key string, val []byte, exp time.Duration) error {
 	// Ain't Nobody Got Time For That


### PR DESCRIPTION
Support for configuring the socket connection pool size for the Redis Storage driver. By default the driver will use up to 10 connections per CPU available. Using `PoolSize` the user can now increase that size.

Default pool size value was taken from:
	- https://github.com/go-redis/redis/blob/master/options.go#L144

Information about connection pool size:
	- https://redis.uptrace.dev/guide/go-redis-debugging.html#connection-pool-size
