### PR TITLE
[Feat] Allow reuse of an existing db connection when creating a MySQL storage driver

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -51,8 +51,16 @@ store := mysql.New(mysql.Config{
 })
 
 // Initialize custom config using connection string
-store := postgres.New(postgres.Config{
-	ConnectionURI:   "mysql://user:password@localhost:3306/fiber"
+store := mysql.New(mysql.Config{
+	ConnectionURI:   "<username>:<pw>@tcp(<HOST>:<port>)/<dbname>"
+	Reset:           false,
+	GCInterval:      10 * time.Second,
+})
+
+// Initialize custom config using sql db connection
+db, _ := sql.Open("mysql", "<username>:<pw>@tcp(<HOST>:<port>)/<dbname>")
+store := mysql.New(mysql.Config{
+	Db:              db,
 	Reset:           false,
 	GCInterval:      10 * time.Second,
 })
@@ -61,6 +69,11 @@ store := postgres.New(postgres.Config{
 ### Config
 ```go
 type Config struct {
+	// DB Will override ConnectionURI and all other authentication values if used
+	//
+	// Optional. Default is nil
+	Db *sql.DB
+	
 	// Connection string to use for DB. Will override all other authentication values if used
 	//
 	// Optional. Default is ""

--- a/mysql/config.go
+++ b/mysql/config.go
@@ -1,12 +1,18 @@
 package mysql
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 )
 
 // Config defines the config for storage.
 type Config struct {
+	// DB Will override ConnectionURI and all other authentication values if used
+	//
+	// Optional. Default is nil
+	Db *sql.DB
+
 	// Connection string to use for DB. Will override all other authentication values if used
 	//
 	// Optional. Default is ""
@@ -63,6 +69,7 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
+	Db:              nil,
 	ConnectionURI:   "",
 	Host:            "127.0.0.1",
 	Port:            3306,

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -40,19 +40,27 @@ var (
 
 // New creates a new storage
 func New(config ...Config) *Storage {
+	var err error
+	var db *sql.DB
+
 	// Set default config
 	cfg := configDefault(config...)
 
-	// Create db
-	db, err := sql.Open("mysql", cfg.dsn())
-	if err != nil {
-		panic(err)
-	}
+	if cfg.Db != nil {
+		// Use passed db
+		db = cfg.Db
+	} else {
+		// Create db
+		db, err = sql.Open("mysql", cfg.dsn())
+		if err != nil {
+			panic(err)
+		}
 
-	// Set options
-	db.SetMaxOpenConns(cfg.maxOpenConns)
-	db.SetMaxIdleConns(cfg.maxIdleConns)
-	db.SetConnMaxLifetime(cfg.connMaxLifetime)
+		// Set options
+		db.SetMaxOpenConns(cfg.maxOpenConns)
+		db.SetMaxIdleConns(cfg.maxIdleConns)
+		db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	}
 
 	// Ping database to ensure a connection has been made
 	if err := db.Ping(); err != nil {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/gofiber/utils"
@@ -26,7 +25,7 @@ func Test_MYSQL_New(t *testing.T) {
 		Reset:    true,
 	})
 
-	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	utils.AssertEqual(t, true, newConfigStore.db != nil)
 	newConfigStore.Close()
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", os.Getenv("MYSQL_USERNAME"), os.Getenv("MYSQL_PASSWORD"), "127.0.0.1", 3306, os.Getenv("MYSQL_DATABASE"))
@@ -35,7 +34,7 @@ func Test_MYSQL_New(t *testing.T) {
 		Reset:         true,
 	})
 
-	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	utils.AssertEqual(t, true, newConfigStore.db != nil)
 	newConfigStore.Close()
 
 	db, _ := sql.Open("mysql", dsn)
@@ -44,7 +43,7 @@ func Test_MYSQL_New(t *testing.T) {
 		Reset: true,
 	})
 
-	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	utils.AssertEqual(t, true, newConfigStore.db != nil)
 	newConfigStore.Close()
 }
 

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -25,23 +25,27 @@ func Test_MYSQL_New(t *testing.T) {
 		Password: os.Getenv("MYSQL_PASSWORD"),
 		Reset:    true,
 	})
+
 	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	newConfigStore.Close()
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", os.Getenv("MYSQL_USERNAME"), os.Getenv("MYSQL_PASSWORD"), "127.0.0.1", 3306, os.Getenv("MYSQL_DATABASE"))
-
 	newConfigStore = New(Config{
 		ConnectionURI: dsn,
 		Reset:         true,
 	})
+
 	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	newConfigStore.Close()
 
 	db, _ := sql.Open("mysql", dsn)
-
 	newConfigStore = New(Config{
 		Db:    db,
 		Reset: true,
 	})
+
 	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+	newConfigStore.Close()
 }
 
 func Test_MYSQL_Set(t *testing.T) {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -2,11 +2,13 @@ package mysql
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
+	"reflect"
 	"testing"
-	"time"
 
 	"github.com/gofiber/utils"
+	"time"
 )
 
 var testStore = New(Config{
@@ -15,6 +17,32 @@ var testStore = New(Config{
 	Password: os.Getenv("MYSQL_PASSWORD"),
 	Reset:    true,
 })
+
+func Test_MYSQL_New(t *testing.T) {
+	newConfigStore := New(Config{
+		Database: os.Getenv("MYSQL_DATABASE"),
+		Username: os.Getenv("MYSQL_USERNAME"),
+		Password: os.Getenv("MYSQL_PASSWORD"),
+		Reset:    true,
+	})
+	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", os.Getenv("MYSQL_USERNAME"), os.Getenv("MYSQL_PASSWORD"), "127.0.0.1", 3306, os.Getenv("MYSQL_DATABASE"))
+
+	newConfigStore = New(Config{
+		ConnectionURI: dsn,
+		Reset:         true,
+	})
+	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+
+	db, _ := sql.Open("mysql", dsn)
+
+	newConfigStore = New(Config{
+		Db:    db,
+		Reset: true,
+	})
+	utils.AssertEqual(t, reflect.TypeOf(newConfigStore.db).String(), "*sql.DB")
+}
 
 func Test_MYSQL_Set(t *testing.T) {
 	var (


### PR DESCRIPTION
Support for passing an existing db connection was requested in this thread: https://github.com/gofiber/storage/issues/147

This pull request implements support for this feature in the MySQL storage driver, allowing the developer to optionally reuse their existing db connection to Get/Set session data.

It also updates the README removing references to postgres.