### PR TITLE
Increase performance for the memory storage

### DIFF
--- a/memory/internal/time.go
+++ b/memory/internal/time.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	timestampTimer sync.Once
+	// Timestamp please start the timer function before you use this value
+	// please load the value with atomic `atomic.LoadUint32(&utils.Timestamp)`
+	Timestamp uint32
+)
+
+// StartTimeStampUpdater starts a concurrent function which stores the timestamp to an atomic value per second,
+// which is much better for performance than determining it at runtime each time
+func StartTimeStampUpdater() {
+	timestampTimer.Do(func() {
+		// set initial value
+		atomic.StoreUint32(&Timestamp, uint32(time.Now().Unix()))
+		go func(sleep time.Duration) {
+			ticker := time.NewTicker(sleep)
+			defer ticker.Stop()
+
+			for t := range ticker.C {
+				// update timestamp
+				atomic.StoreUint32(&Timestamp, uint32(t.Unix()))
+			}
+		}(1 * time.Second) // duration
+	})
+}

--- a/memory/internal/time_test.go
+++ b/memory/internal/time_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/utils"
+)
+
+func checkTimeStamp(t testing.TB, expectedCurrent, actualCurrent uint32) {
+	// test with some buffer in front and back of the expectedCurrent time -> because of the timing on the work machine
+	utils.AssertEqual(t, true, actualCurrent >= expectedCurrent-1 || actualCurrent <= expectedCurrent+1)
+}
+
+func Test_TimeStampUpdater(t *testing.T) {
+	t.Parallel()
+
+	StartTimeStampUpdater()
+
+	now := uint32(time.Now().Unix())
+	checkTimeStamp(t, now, atomic.LoadUint32(&Timestamp))
+	// one second later
+	time.Sleep(1 * time.Second)
+	checkTimeStamp(t, now+1, atomic.LoadUint32(&Timestamp))
+	// two seconds later
+	time.Sleep(1 * time.Second)
+	checkTimeStamp(t, now+2, atomic.LoadUint32(&Timestamp))
+}
+
+func Benchmark_CalculateTimestamp(b *testing.B) {
+	StartTimeStampUpdater()
+
+	var res uint32
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = atomic.LoadUint32(&Timestamp)
+		}
+		checkTimeStamp(b, uint32(time.Now().Unix()), res)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = uint32(time.Now().Unix())
+		}
+		checkTimeStamp(b, uint32(time.Now().Unix()), res)
+	})
+}

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -123,3 +123,31 @@ func Test_Memory_Close(t *testing.T) {
 func Test_Memory_Conn(t *testing.T) {
 	utils.AssertEqual(t, true, testStore.Conn() != nil)
 }
+
+// go test -v -run=^$ -bench=Benchmark_Memory -benchmem -count=4
+func Benchmark_Memory(b *testing.B) {
+	keyLength := 1000
+	keys := make([]string, keyLength)
+	for i := 0; i < keyLength; i++ {
+		keys[i] = utils.UUID()
+	}
+	value := []byte("joe")
+
+	ttl := 2 * time.Second
+	b.Run("fiber_memory", func(b *testing.B) {
+		d := New()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			for _, key := range keys {
+				d.Set(key, value, ttl)
+			}
+			for _, key := range keys {
+				_, _ = d.Get(key)
+			}
+			for _, key := range keys {
+				d.Delete(key)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Memory storage optimized:
```go
Benchmark_Memory/fiber_memory-12         	    7950	    153780 ns/op	     616 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    9714	    134795 ns/op	     657 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    9558	    122996 ns/op	     645 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    9392	    130914 ns/op	     635 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    8590	    123949 ns/op	     645 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    9662	    126010 ns/op	     703 B/op	       0 allocs/op
```

original storage:
```go
Benchmark_Memory/fiber_memory-12         	    3972	    282395 ns/op	     662 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    4204	    279402 ns/op	     723 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    4239	    278725 ns/op	     619 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    4239	    302900 ns/op	     717 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    4288	    282079 ns/op	     703 B/op	       0 allocs/op
Benchmark_Memory/fiber_memory-12         	    4221	    280041 ns/op	     721 B/op	       0 allocs/op
```