### PR TITLE
Use URL Escaping when formatting DSN for Postgres

### DIFF
--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -16,7 +16,7 @@ jobs:
                 env:
                     POSTGRES_DB: fiber
                     POSTGRES_USER: username
-                    POSTGRES_PASSWORD: password
+                    POSTGRES_PASSWORD: "pass#w%rd"
                 options: >-
                     --health-cmd pg_isready --health-interval 10s --health-timeout 5s
                     --health-retries 5
@@ -57,4 +57,4 @@ jobs:
                 env:
                     POSTGRES_DATABASE: fiber
                     POSTGRES_USERNAME: username
-                    POSTGRES_PASSWORD: password
+                    POSTGRES_PASSWORD: "pass#w%rd"

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -55,7 +55,7 @@ func New(config ...Config) *Storage {
 			dsn += url.QueryEscape(cfg.Username)
 		}
 		if cfg.Password != "" {
-			dsn += ":" + cfg.Password
+			dsn += ":" + url.QueryEscape(cfg.Password)
 		}
 		if cfg.Username != "" || cfg.Password != "" {
 			dsn += "@"


### PR DESCRIPTION
* Added URL Escaping for the password field when generating the DSN for Postgres
* Updated the password used during testing to include characters such as `#` and `%`

Fixes #513 