### PR TITLE
Fix incorrect default timeout value for Coherence storage driver

### DIFF
--- a/coherence/coherence.go
+++ b/coherence/coherence.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultScopeName = "default-store"
-	defaultTimeout   = time.Duration(30) * time.Millisecond
+	defaultTimeout   = time.Duration(30) * time.Second
 )
 
 // Storage represents an implementation of Coherence storage provider.


### PR DESCRIPTION
This PR is to change the default timeout which was incorrectly set to 30 millis instead of 30 seconds.