### PR TITLE
feat: Decouple NATS storage driver from gofiber/fiber

### DIFF
--- a/.github/workflows/test-nats.yml
+++ b/.github/workflows/test-nats.yml
@@ -16,6 +16,7 @@ jobs:
                 go-version:
                     - 1.20.x
                     - 1.21.x
+                    - 1.22.x
         runs-on: ubuntu-latest
         steps:
             -   name: Fetch Repository
@@ -29,6 +30,6 @@ jobs:
             -   name: Run NATS
                 run: |
                     docker run -d --name nats-jetstream -p 4443:4443 -v ./nats/testdata:/testdata -v ./tls:/tls nats:latest --jetstream -c /testdata/nats-tls.conf
-                    sleep 2
+                    sleep 5
             -   name: Test Nats
                 run: cd ./nats && go test ./... -v -race

--- a/nats/README.md
+++ b/nats/README.md
@@ -12,7 +12,7 @@ title: Nats
 
 A NATS Key/Value storage driver.
 
-**Note: Requires Go 1.20 and above**
+## Note: Requires Go 1.20 and above
 
 ### Table of Contents
 
@@ -57,7 +57,7 @@ Import the storage package.
 import "github.com/gofiber/storage/nats"
 ```
 
-You can use the following possibilities to create a storage:
+You can use the following options to create a storage driver:
 
 ```go
 // Initialize default config
@@ -65,16 +65,16 @@ store := nats.New()
 
 // Initialize custom config
 store := nats.New(Config{
- URLs: "nats://127.0.0.1:4443",
- NatsOptions: []nats.Option{
-  nats.MaxReconnects(2),
-  // Enable TLS by specifying RootCAs
-  nats.RootCAs("./testdata/certs/ca.pem"),
- },
- KeyValueConfig: jetstream.KeyValueConfig{
-  Bucket:  "test",
-  Storage: jetstream.MemoryStorage,
- },
+    URLs: "nats://127.0.0.1:4443",
+    NatsOptions: []nats.Option{
+        nats.MaxReconnects(2),
+        // Enable TLS by specifying RootCAs
+        nats.RootCAs("./testdata/certs/ca.pem"),
+    },
+    KeyValueConfig: jetstream.KeyValueConfig{
+        Bucket:  "test",
+        Storage: jetstream.MemoryStorage,
+    },
 })
 ```
 
@@ -82,22 +82,18 @@ store := nats.New(Config{
 
 ```go
 type Config struct {
- // Nats URLs, default "nats://127.0.0.1:4222". Can be comma separated list for multiple servers
- URLs string
- // Nats connection options. See nats_test.go for an example of how to use this.
- NatsOptions []nats.Option
- // Nats connection name
- ClientName string
- // Nats context
- Context context.Context
- // Nats key value config
- KeyValueConfig jetstream.KeyValueConfig
- // Logger. Using Fiber AllLogger interface for adapting the various log libraries.
- Logger log.AllLogger
- // Use the Logger for nats events, default: false
- Verbose bool
- // Wait for connection to be established, default: 100ms
- WaitForConnection time.Duration
+    // Nats URLs, default "nats://127.0.0.1:4222". Can be comma separated list for multiple servers
+    URLs string
+    // Nats connection options. See nats_test.go for an example of how to use this.
+    NatsOptions []nats.Option
+    // Nats connection name
+    ClientName string
+    // Nats context
+    Context context.Context
+    // Nats key value config
+    KeyValueConfig jetstream.KeyValueConfig
+    // Wait for connection to be established, default: 100ms
+    WaitForConnection time.Duration
 }
 ```
 
@@ -105,12 +101,12 @@ type Config struct {
 
 ```go
 var ConfigDefault = Config{
- URLs:       nats.DefaultURL,
- Context:    context.Background(),
- ClientName: "fiber_storage",
- KeyValueConfig: jetstream.KeyValueConfig{
-  Bucket: "fiber_storage",
- },
- WaitForConnection: 100 * time.Millisecond,
+    URLs:       nats.DefaultURL,
+    Context:    context.Background(),
+    ClientName: "fiber_storage",
+    KeyValueConfig: jetstream.KeyValueConfig{
+    Bucket: "fiber_storage",
+    },
+    WaitForConnection: 100 * time.Millisecond,
 }
 ```

--- a/nats/config.go
+++ b/nats/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gofiber/fiber/v2/log"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -21,11 +20,7 @@ type Config struct {
 	Context context.Context
 	// Nats key value config
 	KeyValueConfig jetstream.KeyValueConfig
-	// Logger. Using Fiber AllLogger interface for adapting the various log libraries.
-	Logger log.AllLogger
-	// Use the Logger for nats events, default: false
-	Verbose bool
-	// Wait for connection to be established, default: 100ms
+	// Wait for connection to be established, default: 250ms
 	WaitForConnection time.Duration
 }
 
@@ -37,7 +32,7 @@ var ConfigDefault = Config{
 	KeyValueConfig: jetstream.KeyValueConfig{
 		Bucket: "fiber_storage",
 	},
-	WaitForConnection: 100 * time.Millisecond,
+	WaitForConnection: 250 * time.Millisecond,
 }
 
 // Helper function to set default values
@@ -54,22 +49,19 @@ func configDefault(config ...Config) Config {
 	if cfg.URLs == "" {
 		cfg.URLs = ConfigDefault.URLs
 	}
+
 	if cfg.Context == nil {
 		cfg.Context = ConfigDefault.Context
 	}
+
 	if len(cfg.KeyValueConfig.Bucket) == 0 {
 		cfg.KeyValueConfig.Bucket = ConfigDefault.KeyValueConfig.Bucket
 	}
-	if cfg.Verbose {
-		if cfg.Logger == nil {
-			cfg.Logger = log.DefaultLogger()
-		}
-	} else {
-		cfg.Logger = nil
-	}
+
 	if cfg.ClientName == "" {
 		cfg.ClientName = ConfigDefault.ClientName
 	}
+
 	if cfg.WaitForConnection == 0 {
 		cfg.WaitForConnection = ConfigDefault.WaitForConnection
 	}

--- a/nats/go.mod
+++ b/nats/go.mod
@@ -3,7 +3,6 @@ module github.com/gofiber/storage/nats
 go 1.20
 
 require (
-	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/nats-io/nats.go v1.36.0
 	github.com/stretchr/testify v1.9.0
 )
@@ -14,7 +13,6 @@ require (
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/nats/go.sum
+++ b/nats/go.sum
@@ -1,8 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
-github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/nats-io/nats.go v1.36.0 h1:suEUPuWzTSse/XhESwqLxXGuj8vGRuPRoG7MoRN/qyU=
@@ -15,8 +12,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
-github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=


### PR DESCRIPTION
## Description

- Decouple the `NATS` storage driver from https://github.com/gofiber/fiber by removing the `fiberlog`.
- Remove the embedded logging functions.
- Remove the `logger` and `verbose` params.

Note: This is the only Storage driver that depends on `gofiber/fiber`, removing this dependency will decouple this whole repo from `gofiber/fiber`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified requirements for Go version and improved terminology in NATS Key/Value storage driver documentation.

- **Configuration**
  - Adjusted default wait time for connection establishment from 100ms to 250ms.

- **Testing**
  - Added Go 1.22.x to test workflow.
  - Increased sleep duration before testing NATS from 2 to 5 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->