### PR TITLE
Add MaxRetry for MinIO operations

### DIFF
--- a/minio/README.md
+++ b/minio/README.md
@@ -94,6 +94,10 @@ type Config struct {
     // Optional. Default is false
     Reset bool
     
+    // The maximum number of times requests that encounter retryable failures should be attempted.
+	// Optional. Default is 10, same as the MinIO client.
+	MaxRetry int
+
     // Credentials Minio access key and Minio secret key.
     // Need to be defined
     Credentials Credentials
@@ -124,6 +128,7 @@ var ConfigDefault = Config{
     Token:               "",
     Secure:              false,
     Reset:               false,
+
     Credentials:         Credentials{},
     GetObjectOptions:    minio.GetObjectOptions{},
     PutObjectOptions:    minio.PutObjectOptions{},

--- a/minio/config.go
+++ b/minio/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	// Optional. Default is false
 	Reset bool
 
+	// The maximum number of times requests that encounter retryable failures should be attempted.
+	// Optional. Default is 10, same as the MinIO client.
+	MaxRetry int
+
 	// Credentials Minio access key and Minio secret key.
 	// Need to be defined
 	Credentials Credentials
@@ -62,6 +66,7 @@ var ConfigDefault = Config{
 	Token:               "",
 	Secure:              false,
 	Reset:               false,
+	MaxRetry:            minio.MaxRetry,
 	Credentials:         Credentials{},
 	GetObjectOptions:    minio.GetObjectOptions{},
 	PutObjectOptions:    minio.PutObjectOptions{},

--- a/minio/minio.go
+++ b/minio/minio.go
@@ -28,6 +28,9 @@ func New(config ...Config) *Storage {
 	// Set default config
 	cfg := configDefault(config...)
 
+	// Set MaxRetry
+	minio.MaxRetry = cfg.MaxRetry
+
 	// Minio instance
 	minioClient, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(cfg.Credentials.AccessKeyID, cfg.Credentials.SecretAccessKey, cfg.Token),


### PR DESCRIPTION
This PR introduces a new MaxRetry configuration option to the Config struct, allowing users to specify the maximum number of retry attempts for MinIO operations.