### PR TITLE
🧹 chore: Add Valkey 8.x to test workflow

### DIFF
--- a/.github/workflows/test-valkey.yml
+++ b/.github/workflows/test-valkey.yml
@@ -17,7 +17,8 @@ jobs:
                 go-version:
                     - 1.23.x
                 valkey:
-                    - '7.2'
+                    - '7.x'
+                    - '8.x'
         steps:
             -   name: Fetch Repository
                 uses: actions/checkout@v4


### PR DESCRIPTION
- Add v8.x to Valkey test workflow.

Support for this was released today https://github.com/shogo82148/actions-setup-redis/releases/tag/v1.36.0