### PR TITLE
♻️refactor(s3): WithEndpointResolver is deprecated

### DIFF
--- a/dynamodb/dynamodb.go
+++ b/dynamodb/dynamodb.go
@@ -44,7 +44,9 @@ func New(config Config) *Storage {
 	}
 
 	// Create db
-	sess := awsdynamodb.NewFromConfig(awscfg)
+	sess := awsdynamodb.NewFromConfig(awscfg, func(o *awsdynamodb.Options) {
+		o.BaseEndpoint = aws.String(cfg.Endpoint)
+	})
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -232,23 +234,10 @@ func (s *Storage) requestContext() (context.Context, context.CancelFunc) {
 }
 
 func returnAWSConfig(cfg Config) (aws.Config, error) {
-	endpoint := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		if cfg.Endpoint != "" {
-			return aws.Endpoint{
-				PartitionID:       "aws",
-				URL:               cfg.Endpoint,
-				SigningRegion:     cfg.Region,
-				HostnameImmutable: true,
-			}, nil
-		}
-		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-	})
-
 	if cfg.Credentials != (Credentials{}) {
 		credentials := credentials.NewStaticCredentialsProvider(cfg.Credentials.AccessKey, cfg.Credentials.SecretAccessKey, "")
 		return awsconfig.LoadDefaultConfig(context.TODO(),
 			awsconfig.WithRegion(cfg.Region),
-			awsconfig.WithEndpointResolverWithOptions(endpoint),
 			awsconfig.WithCredentialsProvider(credentials),
 			awsconfig.WithRetryer(func() aws.Retryer {
 				return retry.AddWithMaxAttempts(retry.NewStandard(), cfg.MaxAttempts)
@@ -258,7 +247,6 @@ func returnAWSConfig(cfg Config) (aws.Config, error) {
 
 	return awsconfig.LoadDefaultConfig(context.TODO(),
 		awsconfig.WithRegion(cfg.Region),
-		awsconfig.WithEndpointResolverWithOptions(endpoint),
 		awsconfig.WithRetryer(func() aws.Retryer {
 			return retry.AddWithMaxAttempts(retry.NewStandard(), cfg.MaxAttempts)
 		}),


### PR DESCRIPTION
`aws.Endpoint`, `awsconfig.WithEndpointResolverWithOptions`, `aws.EndpointResolverWithOptionsFunc` were deprecated.

According to the following document [https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-endpoints.html#v2-endpointresolverv2--baseendpoint](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-endpoints.html#v2-endpointresolverv2--baseendpoint), use `BaseEndpoint` for the migration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced S3 and DynamoDB client configurations with support for custom endpoints
- **Refactor**
	- Simplified S3 and DynamoDB client endpoint configuration processes
	- Removed custom endpoint resolver logic from both S3 and DynamoDB configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->