### PR TITLE
fix(minio): close object after GetObject has returned

### DIFF
--- a/minio/minio.go
+++ b/minio/minio.go
@@ -75,6 +75,7 @@ func (s *Storage) Get(key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer object.Close()
 
 	// convert to byte
 	bb := bytebufferpool.Get()


### PR DESCRIPTION
This prevents a goroutine leak by the minio client from happening.
I found this issue because a data retrieval endpoint kept it's minio goroutine alive.
Then I stumbled upon https://github.com/minio/minio-go/issues/1508 and saw the fiber wrapper didn't close the object!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management when retrieving objects from MinIO storage by ensuring proper object closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->