### PR TITLE
fix(coherence): set coherence log level to ERROR in benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,6 +111,7 @@ jobs:
           TEST_REDIS_IMAGE: "docker.io/redis:7"
           TEST_SCYLLADB_IMAGE: "scylladb/scylla:6.2"
           TEST_SURREALDB_IMAGE: "surrealdb/surrealdb:latest"
+          COHERENCE_LOG_LEVEL: "ERROR"
 
       - name: Get Previous Benchmark Results
         uses: actions/cache@v4


### PR DESCRIPTION
## What does this PR do?
It adds an env var to the benchmarks GH workflow, so that the coherence client does not outputs any debug message.

## Why is it important?
Because the coherence go client outputs some debug messages, the benchmarks file contains those debug messages, causing the processing benchmarks files step to fail because of a malformed file.

## Related issues
- Relates #1733
