### PR TITLE
Fix bbolt deprecation warning

### DIFF
--- a/bbolt/utils.go
+++ b/bbolt/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/gofiber/utils/v2"
 	"go.etcd.io/bbolt"
+	berrors "go.etcd.io/bbolt/errors"
 )
 
 func createBucket(cfg Config, conn *bbolt.DB) error {
@@ -17,7 +18,7 @@ func createBucket(cfg Config, conn *bbolt.DB) error {
 func removeBucket(cfg Config, conn *bbolt.DB) error {
 	return conn.Update(func(tx *bbolt.Tx) error {
 		err := tx.DeleteBucket(utils.UnsafeBytes(cfg.Bucket))
-		if errors.Is(err, bbolt.ErrBucketNotFound) {
+		if errors.Is(err, berrors.ErrBucketNotFound) {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
- use new error variable from `go.etcd.io/bbolt/errors`

## Testing
- `go test ./...`
- `golangci-lint run --timeout=5m`


------
https://chatgpt.com/codex/tasks/task_e_686cf77b7d888326beb8a6030c46dc58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal error handling for bucket deletion to ensure more consistent error responses when a bucket is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->