### PR TITLE
feat(redis): add IsClusterMode support for AWS ElastiCache Configuration Endpoints

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -86,6 +86,12 @@ store := redis.New(redis.Config{
 	Addrs:            []string{":6379", ":6380"},
 })
 
+// Initialize AWS ElastiCache Redis Cluster with Configuration Endpoint
+store := redis.New(redis.Config{
+	Addrs:         []string{"cluster.xxxxx.cache.amazonaws.com:6379"},
+	IsClusterMode: true,
+})
+
 // Create a client with support for TLS
 cer, err := tls.LoadX509KeyPair("./client.crt", "./client.key")
 if err != nil {
@@ -183,6 +189,12 @@ type Config struct {
 	//
 	// Optional. Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
 	PoolSize int
+
+	// IsClusterMode forces cluster mode even with single address.
+	// Useful for AWS ElastiCache Configuration Endpoints.
+	//
+	// Optional. Default is false
+	IsClusterMode bool
 }
 ```
 
@@ -203,6 +215,7 @@ var ConfigDefault = Config{
 	ClientName:            "",
 	SentinelUsername:      "",
 	SentinelPassword:      "",
+	IsClusterMode:         false,
 }
 ```
 

--- a/redis/config.go
+++ b/redis/config.go
@@ -77,6 +77,12 @@ type Config struct {
 	//
 	// Optional. Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
 	PoolSize int
+
+	// IsClusterMode forces cluster mode even with single address.
+	// Useful for AWS ElastiCache Configuration Endpoints.
+	//
+	// Optional. Default is false
+	IsClusterMode bool
 }
 
 // ConfigDefault is the default config
@@ -95,6 +101,7 @@ var ConfigDefault = Config{
 	ClientName:       "",
 	SentinelUsername: "",
 	SentinelPassword: "",
+	IsClusterMode:    false,
 }
 
 // Helper function to set default values

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -62,6 +62,7 @@ func New(config ...Config) *Storage {
 		Password:         cfg.Password,
 		TLSConfig:        cfg.TLSConfig,
 		PoolSize:         cfg.PoolSize,
+		IsClusterMode:    cfg.IsClusterMode,
 	})
 
 	// Test connection


### PR DESCRIPTION
## Description
Adds `IsClusterMode` field to Redis storage Config to support AWS ElastiCache Redis Cluster mode with Configuration Endpoints.

## Problem
When connecting to AWS ElastiCache Redis Cluster using a Configuration Endpoint, connections fail with `MOVED` errors because:
- Configuration Endpoint provides only one address
- `redis.NewUniversalClient` creates single-node client instead of cluster client
- Missing `IsClusterMode` option to force cluster mode

## Solution
- Add `IsClusterMode bool` field to `Config` struct
- Pass `IsClusterMode` to `redis.UniversalOptions`
- Update documentation with AWS ElastiCache example

## Usage
```go
store := redis.New(redis.Config{
    Addrs:         []string{"cluster.xxxxx.cache.amazonaws.com:6379"},
    IsClusterMode: true,
})


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for AWS ElastiCache configuration endpoints by allowing cluster mode to be forced via a new Redis configuration option. Works with a single endpoint; defaults remain unchanged. Improves compatibility and simplifies setup.

* Documentation
  * Updated Redis connection instructions with steps and an example for initializing ElastiCache using a single endpoint with cluster mode enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->